### PR TITLE
Fix jQuery dependency issue preventing word cloud rendering

### DIFF
--- a/control.php
+++ b/control.php
@@ -33,9 +33,9 @@ class D3WordCloud_WidgetShortcodeControl extends WidgetShortcodeControl
 	 */
 	public function enqueue_scripts()
 	{
-		wp_enqueue_script( 'd3-library', plugins_url( '/scripts/d3.min.js' , __FILE__ ), '3.0.min' );
+		wp_enqueue_script( 'd3-library', plugins_url( '/scripts/d3.min.js' , __FILE__ ), array(), '3.0.min' );
 		wp_enqueue_script( 'd3-layout-cloud', plugins_url( '/scripts/d3.layout.cloud.js' , __FILE__ ), array('d3-library'), '1.0.5' );
-		wp_enqueue_script( 'd3-word-cloud', plugins_url( '/scripts/cloud.js' , __FILE__ ), array('d3-library', 'd3-layout-cloud'), '1.0.1' );
+		wp_enqueue_script( 'd3-word-cloud', plugins_url( '/scripts/cloud.js' , __FILE__ ), array('jquery', 'd3-library', 'd3-layout-cloud'), '1.0.1' );
 	}
 	
 	


### PR DESCRIPTION
- Add jQuery as dependency to d3-word-cloud script
- Fix wp_enqueue_script() parameter order for proper script loading
- Resolves 'jQuery is not defined' error that prevented SVG generation

This fixes the issue where word clouds would appear in HTML markup but the SVG elements remained empty due to JavaScript execution failure.

Tested with WordPress 6.x and modern browsers.